### PR TITLE
Pin zipp version and Remove Support for Python 3.7, 3.8 and 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.7'
-          - '3.8'
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 astroid==2.15.8
+zipp==3.19.1
 flake8
 flake8-assertive
 flake8-comprehensions


### PR DESCRIPTION
Pin zipp version to fix vulnerability alerted by Snyk