### PR TITLE
chore: group all Renovate dependency updates into a single PR (config)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,14 +14,12 @@
         "*"
       ],
       "matchUpdateTypes": [
+        "major",
         "minor",
         "patch"
       ],
-      "matchCategories": [
-        "python"
-      ],
-      "groupName": "all non-major python dependencies",
-      "groupSlug": "all-minor-patch-python"
+      "groupName": "all dependencies",
+      "groupSlug": "all-dependencies"
     }
   ]
 }


### PR DESCRIPTION
Reconfigures Renovate so ALL dependency updates (major + minor + patch) group into a **single "all dependencies" PR** per repo, instead of one PR per dependency.

**Effect once merged:** on Renovate's next scheduled run it opens one consolidated PR and **supersedes/auto-closes the individual dependency PRs** in this repo — giving one testable branch for the dependency upgrade. Lockfile is handled by Renovate's own pipeline (`lockFileMaintenance`).

Part of a fleet-wide consolidation across Intsights repos with open Renovate PRs. Opened as a draft for review.